### PR TITLE
fix(dialog): prepare 0.1.3 release

### DIFF
--- a/.changeset/calm-dialogs-listen.md
+++ b/.changeset/calm-dialogs-listen.md
@@ -1,0 +1,6 @@
+---
+"@opentui-ui/dialog": patch
+---
+
+Support OpenTUI 0.4.3 through 0.5.x, including correct dialog removal and
+warning-free React and Solid provider teardown.

--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -50,7 +50,7 @@
 ## Installation
 
 ```bash
-bun add @tuiparts/dialog
+bun add @opentui-ui/dialog
 ```
 
 ---
@@ -62,7 +62,7 @@ Use the core API when working directly with `@opentui/core` renderables without 
 ### Quick Start
 
 ```ts
-import { DialogContainerRenderable, DialogManager } from "@tuiparts/dialog";
+import { DialogContainerRenderable, DialogManager } from "@opentui-ui/dialog";
 import { TextRenderable } from "@opentui/core";
 
 // 1. Create the manager and container
@@ -317,7 +317,7 @@ import {
   useDialog,
   useDialogKeyboard,
   useDialogState,
-} from "@tuiparts/dialog/react";
+} from "@opentui-ui/dialog/react";
 
 // Solid
 import {
@@ -325,7 +325,7 @@ import {
   useDialog,
   useDialogKeyboard,
   useDialogState,
-} from "@tuiparts/dialog/solid";
+} from "@opentui-ui/dialog/solid";
 
 function App() {
   return (
@@ -339,8 +339,8 @@ function App() {
 #### Using Themes
 
 ```tsx
-import { DialogProvider } from "@tuiparts/dialog/react";
-import { themes } from "@tuiparts/dialog/themes";
+import { DialogProvider } from "@opentui-ui/dialog/react";
+import { themes } from "@opentui-ui/dialog/themes";
 
 function App() {
   return (
@@ -527,7 +527,7 @@ When using `useKeyboard` from `@opentui/react` or `@opentui/solid` inside dialog
 `useDialogKeyboard` solves this by only firing the handler when the dialog is the topmost in the stack:
 
 ```tsx
-import { useDialogKeyboard, type ConfirmContext } from "@tuiparts/dialog/react";
+import { useDialogKeyboard, type ConfirmContext } from "@opentui-ui/dialog/react";
 
 function DeleteConfirmDialog({ resolve, dialogId }: ConfirmContext) {
   const [selected, setSelected] = useState<"cancel" | "delete">("cancel");
@@ -563,7 +563,7 @@ If you need more control, use `dialogId` with `useDialogState` and the standard 
 
 ```tsx
 import { useKeyboard } from "@opentui/react";
-import { useDialogState, type ConfirmContext } from "@tuiparts/dialog/react";
+import { useDialogState, type ConfirmContext } from "@opentui-ui/dialog/react";
 
 function MyDialog({ resolve, dialogId }: ConfirmContext) {
   // Reactively check if this dialog is topmost
@@ -636,11 +636,11 @@ This provides a clean, unobtrusive appearance while still being usable immediate
 
 ### Themes
 
-Theme presets provide alternative visual styles. Import from `@tuiparts/dialog/themes`:
+Theme presets provide alternative visual styles. Import from `@opentui-ui/dialog/themes`:
 
 ```ts
-import { DialogContainerRenderable, DialogManager } from "@tuiparts/dialog";
-import { themes } from "@tuiparts/dialog/themes";
+import { DialogContainerRenderable, DialogManager } from "@opentui-ui/dialog";
+import { themes } from "@opentui-ui/dialog/themes";
 
 const container = new DialogContainerRenderable(renderer, {
   manager,
@@ -743,10 +743,10 @@ import type {
   BaseConfirmOptions,
   BaseDialogActions,
   BasePromptOptions,
-} from "@tuiparts/dialog";
+} from "@opentui-ui/dialog";
 
 // Type guard for close events
-import { isDialogToClose } from "@tuiparts/dialog";
+import { isDialogToClose } from "@opentui-ui/dialog";
 
 // Themes and default style constants
 import {
@@ -756,7 +756,7 @@ import {
   DEFAULT_STYLE,
   themes,
   type DialogTheme,
-} from "@tuiparts/dialog/themes";
+} from "@opentui-ui/dialog/themes";
 ```
 
 ## License

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -1,7 +1,6 @@
 {
-  "name": "@tuiparts/dialog",
+  "name": "@opentui-ui/dialog",
   "version": "0.1.2",
-  "private": true,
   "description": "A dialog/modal library for terminal UIs built on OpenTUI",
   "author": "Matt Simpson",
   "license": "MIT",
@@ -49,6 +48,10 @@
   ],
   "scripts": {
     "build": "tsdown",
+    "test": "bun run test:core && bun run test:react && bun run test:solid",
+    "test:core": "bun test src/dialog.test.ts",
+    "test:react": "bun test src/react.test.tsx",
+    "test:solid": "bun test --preload @opentui/solid/preload src/solid.test.tsx",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },
@@ -56,9 +59,9 @@
     "@babel/core": "^7.29.7",
     "@babel/preset-typescript": "^7.29.7",
     "@tuiparts/utils": "workspace:^",
-    "@opentui/core": "catalog:",
-    "@opentui/react": "catalog:",
-    "@opentui/solid": "catalog:",
+    "@opentui/core": "catalog:dialog-dev",
+    "@opentui/react": "catalog:dialog-dev",
+    "@opentui/solid": "catalog:dialog-dev",
     "@types/bun": "^1.3.14",
     "@types/node": "catalog:",
     "@types/react": "^19.2.17",
@@ -70,15 +73,23 @@
     "ws": "catalog:"
   },
   "peerDependencies": {
-    "@opentui/core": "catalog:",
-    "@opentui/react": "catalog:",
-    "@opentui/solid": "catalog:"
+    "@opentui/core": "catalog:dialog-peer",
+    "@opentui/react": "catalog:dialog-peer",
+    "@opentui/solid": "catalog:dialog-peer",
+    "react": "^19.2.0",
+    "solid-js": "^1.9.0"
   },
   "peerDependenciesMeta": {
     "@opentui/react": {
       "optional": true
     },
     "@opentui/solid": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    },
+    "solid-js": {
       "optional": true
     }
   }

--- a/packages/dialog/scripts/link-dev.sh
+++ b/packages/dialog/scripts/link-dev.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
-# link-dev.sh - Development linking script for @tuiparts/dialog
+# link-dev.sh - Development linking script for @opentui-ui/dialog
 #
-# This script creates a symbolic link (or copy) of the @tuiparts/dialog package
+# This script creates a symbolic link (or copy) of the @opentui-ui/dialog package
 # into another project's node_modules directory for local development and testing.
 #
 # Usage:
@@ -88,7 +88,7 @@ if [ ! -d "$NODE_MODULES_DIR" ]; then
 	exit 1
 fi
 
-echo "Linking @tuiparts/dialog from: $REPO_ROOT"
+echo "Linking @opentui-ui/dialog from: $REPO_ROOT"
 echo "To node_modules in: $NODE_MODULES_DIR"
 echo
 
@@ -127,11 +127,11 @@ else
 	echo "Creating symbolic link..."
 fi
 
-# Link @tuiparts/dialog
-remove_if_exists "$NODE_MODULES_DIR/@tuiparts/dialog"
+# Link @opentui-ui/dialog
+remove_if_exists "$NODE_MODULES_DIR/@opentui-ui/dialog"
 PACKAGE_PATH="$REPO_ROOT$SUFFIX"
 if [ -d "$PACKAGE_PATH" ]; then
-	link_or_copy "$PACKAGE_PATH" "$NODE_MODULES_DIR/@tuiparts/dialog" "@tuiparts/dialog"
+	link_or_copy "$PACKAGE_PATH" "$NODE_MODULES_DIR/@opentui-ui/dialog" "@opentui-ui/dialog"
 else
 	echo "Warning: $PACKAGE_PATH not found"
 fi

--- a/packages/dialog/src/dialog.test.ts
+++ b/packages/dialog/src/dialog.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { BoxRenderable } from "@opentui/core";
+import {
+  createTestRenderer,
+  type TestRendererSetup,
+} from "@opentui/core/testing";
+import { DialogManager } from "./manager";
+import { DialogContainerRenderable } from "./renderables/dialog-container";
+
+let setup: TestRendererSetup | undefined;
+
+afterEach(() => {
+  setup?.renderer.destroy();
+  setup = undefined;
+});
+
+describe("DialogContainerRenderable", () => {
+  it("dismisses the top dialog with Escape and restores focus", async () => {
+    setup = await createTestRenderer({ width: 40, height: 10 });
+    const originalFocus = new BoxRenderable(setup.renderer, {
+      id: "original-focus",
+      focusable: true,
+    });
+    const manager = new DialogManager(setup.renderer);
+    const container = new DialogContainerRenderable(setup.renderer, {
+      manager,
+    });
+    setup.renderer.root.add(originalFocus);
+    setup.renderer.root.add(container);
+    originalFocus.focus();
+
+    const id = manager.show({
+      content: (ctx) => new BoxRenderable(ctx, { id: "dialog-content" }),
+    });
+    const dialog = container.getDialogRenderable(id);
+
+    expect(dialog?.parent).toBe(container);
+    expect(container.visible).toBe(true);
+    await setup.mockInput.pressEscape();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(manager.getDialogs()).toEqual([]);
+    expect(container.getDialogRenderables().size).toBe(0);
+    expect(dialog?.isDestroyed).toBe(true);
+    expect(container.visible).toBe(false);
+    expect(setup.renderer.currentFocusedRenderable).toBe(originalFocus);
+  });
+});

--- a/packages/dialog/src/manager.ts
+++ b/packages/dialog/src/manager.ts
@@ -149,7 +149,7 @@ export class DialogManager {
       try {
         subscriber(data);
       } catch (error) {
-        console.error("[@tuiparts/dialog] Subscriber threw an error:", error);
+        console.error("[@opentui-ui/dialog] Subscriber threw an error:", error);
       }
     }
   }
@@ -173,25 +173,25 @@ export class DialogManager {
   show(options: DialogShowOptions): DialogId {
     if (this.destroyed) {
       throw new Error(
-        "[@tuiparts/dialog] Cannot show dialog: DialogManager has been destroyed.",
+        "[@opentui-ui/dialog] Cannot show dialog: DialogManager has been destroyed.",
       );
     }
 
     if (options.content === undefined || options.content === null) {
       throw new Error(
-        `[@tuiparts/dialog] Missing required 'content' property.\n\n` +
+        `[@opentui-ui/dialog] Missing required 'content' property.\n\n` +
           `The 'content' property must be a factory function that returns a Renderable:\n\n` +
           `  manager.show({\n` +
           `    content: (ctx) => new TextRenderable(ctx, { content: "Hello" }),\n` +
           `  });\n\n` +
-          `For React, use: import { useDialog } from '@tuiparts/dialog/react'\n` +
-          `For Solid, use: import { useDialog } from '@tuiparts/dialog/solid'`,
+          `For React, use: import { useDialog } from '@opentui-ui/dialog/react'\n` +
+          `For Solid, use: import { useDialog } from '@opentui-ui/dialog/solid'`,
       );
     }
 
     if (typeof options.content !== "function") {
       throw new Error(
-        `[@tuiparts/dialog] Invalid 'content' type: expected function, got ${typeof options.content}.\n\n` +
+        `[@opentui-ui/dialog] Invalid 'content' type: expected function, got ${typeof options.content}.\n\n` +
           `The 'content' property must be a factory function that receives a RenderContext\n` +
           `and returns a Renderable:\n\n` +
           `  manager.show({\n` +
@@ -199,8 +199,8 @@ export class DialogManager {
           `  });\n\n` +
           `If you're using React or Solid, make sure you're importing from\n` +
           `the correct entry point:\n` +
-          `  - React: import { useDialog } from '@tuiparts/dialog/react'\n` +
-          `  - Solid: import { useDialog } from '@tuiparts/dialog/solid'`,
+          `  - React: import { useDialog } from '@opentui-ui/dialog/react'\n` +
+          `  - Solid: import { useDialog } from '@opentui-ui/dialog/solid'`,
       );
     }
 

--- a/packages/dialog/src/react.test.tsx
+++ b/packages/dialog/src/react.test.tsx
@@ -1,0 +1,38 @@
+/** @jsxImportSource @opentui/react */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import type { TestRendererSetup } from "@opentui/core/testing";
+import { testRender } from "@opentui/react/test-utils";
+import { act, createElement } from "react";
+import { DialogProvider } from "./react";
+import type { DialogContainerRenderable } from "./renderables/dialog-container";
+
+let setup: TestRendererSetup | undefined;
+
+afterEach(async () => {
+  await act(async () => setup?.renderer.destroy());
+  setup = undefined;
+});
+
+describe("React DialogProvider", () => {
+  it("destroys and detaches its container during renderer teardown", async () => {
+    setup = await testRender(
+      createElement(
+        DialogProvider,
+        null,
+        createElement("text", { content: "Application" }),
+      ),
+      { width: 40, height: 10 },
+    );
+    const container = setup.renderer.root.findDescendantById(
+      "dialog-container",
+    ) as DialogContainerRenderable;
+
+    expect(container.parent).toBe(setup.renderer.root);
+    await act(async () => setup?.renderer.destroy());
+    setup = undefined;
+
+    expect(container.isDestroyed).toBe(true);
+    expect(container.parent).toBeNull();
+  });
+});

--- a/packages/dialog/src/react.tsx
+++ b/packages/dialog/src/react.tsx
@@ -166,7 +166,7 @@ function useDialogManager(): DialogManager {
     throw new Error(
       "useDialog/useDialogState must be used within a DialogProvider.\n\n" +
         "Wrap your app with <DialogProvider>:\n\n" +
-        "  import { DialogProvider } from '@tuiparts/dialog/react';\n\n" +
+        "  import { DialogProvider } from '@opentui-ui/dialog/react';\n\n" +
         "  function App() {\n" +
         "    return (\n" +
         "      <DialogProvider>\n" +
@@ -373,7 +373,6 @@ export function DialogProvider(props: DialogProviderProps) {
     renderer.root.add(container);
 
     return () => {
-      renderer.root.remove(container);
       container.destroyRecursively();
       manager.destroy();
     };

--- a/packages/dialog/src/renderables/backdrop.ts
+++ b/packages/dialog/src/renderables/backdrop.ts
@@ -61,7 +61,7 @@ export class BackdropRenderable extends BoxRenderable {
     const opacity = normalizeOpacity(
       dialog?.backdropOpacity ?? containerOptions.backdropOpacity,
       DEFAULT_BACKDROP_OPACITY,
-      "@tuiparts/dialog",
+      "@opentui-ui/dialog",
     );
     const rgba = parseColor(color);
     rgba.a = opacity / 255;

--- a/packages/dialog/src/renderables/dialog.ts
+++ b/packages/dialog/src/renderables/dialog.ts
@@ -75,7 +75,7 @@ export class DialogRenderable extends BoxRenderable {
       const originalStack = error instanceof Error ? error.stack : undefined;
 
       const enhancedError = new Error(
-        `[@tuiparts/dialog] Failed to create content for dialog "${dialogId}".\n\n` +
+        `[@opentui-ui/dialog] Failed to create content for dialog "${dialogId}".\n\n` +
           `Root cause: ${originalMessage}\n\n` +
           `This error occurred while executing the content factory function. ` +
           `Check that your content factory returns a valid Renderable and doesn't throw.\n\n` +

--- a/packages/dialog/src/solid.test.tsx
+++ b/packages/dialog/src/solid.test.tsx
@@ -1,0 +1,37 @@
+/** @jsxImportSource @opentui/solid */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import type { TestRendererSetup } from "@opentui/core/testing";
+import { testRender } from "@opentui/solid";
+import type { DialogContainerRenderable } from "./renderables/dialog-container";
+import { DialogProvider } from "./solid";
+
+let setup: TestRendererSetup | undefined;
+
+afterEach(() => {
+  setup?.renderer.destroy();
+  setup = undefined;
+});
+
+describe("Solid DialogProvider", () => {
+  it("destroys and detaches its container during renderer teardown", async () => {
+    setup = await testRender(
+      () => (
+        <DialogProvider>
+          <text content="Application" />
+        </DialogProvider>
+      ),
+      { width: 40, height: 10 },
+    );
+    const container = setup.renderer.root.findDescendantById(
+      "dialog-container",
+    ) as DialogContainerRenderable;
+
+    expect(container.parent).toBe(setup.renderer.root);
+    setup.renderer.destroy();
+    setup = undefined;
+
+    expect(container.isDestroyed).toBe(true);
+    expect(container.parent).toBeNull();
+  });
+});

--- a/packages/dialog/src/solid.tsx
+++ b/packages/dialog/src/solid.tsx
@@ -180,7 +180,7 @@ function validateContentAccessor(
 ): asserts content is ContentAccessor {
   if (typeof content !== "function") {
     throw new Error(
-      `[@tuiparts/dialog/solid] Invalid content type: expected a function returning JSX, but received ${typeof content}.\n\n` +
+      `[@opentui-ui/dialog/solid] Invalid content type: expected a function returning JSX, but received ${typeof content}.\n\n` +
         `Solid.js JSX is eagerly evaluated, so you must wrap content in a function:\n\n` +
         `  // CORRECT\n` +
         `  dialog.show({ content: () => <text>Hello</text> })\n\n` +
@@ -198,7 +198,7 @@ function useDialogContext(): DialogContextValue {
     throw new Error(
       "useDialog/useDialogState must be used within a DialogProvider.\n\n" +
         "Wrap your app with <DialogProvider>:\n\n" +
-        "  import { DialogProvider } from '@tuiparts/dialog/solid';\n\n" +
+        "  import { DialogProvider } from '@opentui-ui/dialog/solid';\n\n" +
         "  function App() {\n" +
         "    return (\n" +
         "      <DialogProvider>\n" +
@@ -416,7 +416,6 @@ export function DialogProvider(props: ParentProps<DialogProviderProps>) {
     disposed = true;
     unsubscribe();
     portalItemCache.clear();
-    renderer.root.remove(container);
     container.destroyRecursively();
     manager.destroy();
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,19 +8,29 @@ catalogs:
   default:
     '@opentui/core':
       specifier: ^0.4.3
-      version: 0.4.3
+      version: 0.4.5
     '@opentui/react':
       specifier: ^0.4.3
-      version: 0.4.3
+      version: 0.4.5
     '@opentui/solid':
       specifier: ^0.4.3
-      version: 0.4.3
+      version: 0.4.5
     '@types/node':
       specifier: ^24.13.3
       version: 24.13.3
     ws:
       specifier: ^8.21.0
       version: 8.21.0
+  dialog-dev:
+    '@opentui/core':
+      specifier: ^0.5.10
+      version: 0.5.10
+    '@opentui/react':
+      specifier: ^0.5.10
+      version: 0.5.10
+    '@opentui/solid':
+      specifier: ^0.5.10
+      version: 0.5.10
 
 overrides:
   path-to-regexp@6.1.0: 6.3.0
@@ -83,7 +93,7 @@ importers:
     dependencies:
       '@opentui/core':
         specifier: 'catalog:'
-        version: 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        version: 0.4.5(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@tuiparts/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -102,10 +112,10 @@ importers:
     dependencies:
       '@opentui/core':
         specifier: 'catalog:'
-        version: 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        version: 0.4.5(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@opentui/react':
         specifier: 'catalog:'
-        version: 0.4.3(react-devtools-core@7.0.1)(react@19.2.7)(typescript@5.9.3)(web-tree-sitter@0.25.10)(ws@8.21.0)
+        version: 0.4.5(react-devtools-core@7.0.1)(react@19.2.7)(typescript@5.9.3)(web-tree-sitter@0.25.10)(ws@8.21.0)
       '@tuiparts/react':
         specifier: workspace:*
         version: link:../../packages/react
@@ -133,10 +143,10 @@ importers:
     dependencies:
       '@opentui/core':
         specifier: 'catalog:'
-        version: 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        version: 0.4.5(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@opentui/solid':
         specifier: 'catalog:'
-        version: 0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        version: 0.4.5(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@tuiparts/solid':
         specifier: workspace:*
         version: link:../../packages/solid
@@ -167,7 +177,7 @@ importers:
     devDependencies:
       '@opentui/core':
         specifier: 'catalog:'
-        version: 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        version: 0.4.5(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@types/bun':
         specifier: ^1.3.14
         version: 1.3.14
@@ -190,14 +200,14 @@ importers:
         specifier: ^7.29.7
         version: 7.29.7(@babel/core@7.29.7)
       '@opentui/core':
-        specifier: 'catalog:'
-        version: 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        specifier: catalog:dialog-dev
+        version: 0.5.10(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@opentui/react':
-        specifier: 'catalog:'
-        version: 0.4.3(react-devtools-core@7.0.1)(react@19.2.7)(typescript@5.9.3)(web-tree-sitter@0.25.10)(ws@8.21.0)
+        specifier: catalog:dialog-dev
+        version: 0.5.10(react-devtools-core@7.0.1)(react@19.2.7)(typescript@5.9.3)(web-tree-sitter@0.25.10)(ws@8.21.0)
       '@opentui/solid':
-        specifier: 'catalog:'
-        version: 0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        specifier: catalog:dialog-dev
+        version: 0.5.10(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@tuiparts/utils':
         specifier: workspace:^
         version: link:../utils
@@ -237,10 +247,10 @@ importers:
     devDependencies:
       '@opentui/core':
         specifier: 'catalog:'
-        version: 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        version: 0.4.5(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@opentui/react':
         specifier: 'catalog:'
-        version: 0.4.3(react-devtools-core@7.0.1)(react@19.2.7)(typescript@5.9.3)(web-tree-sitter@0.25.10)(ws@8.21.0)
+        version: 0.4.5(react-devtools-core@7.0.1)(react@19.2.7)(typescript@5.9.3)(web-tree-sitter@0.25.10)(ws@8.21.0)
       '@types/bun':
         specifier: ^1.3.14
         version: 1.3.14
@@ -274,10 +284,10 @@ importers:
         version: 7.29.7(@babel/core@7.29.7)
       '@opentui/core':
         specifier: 'catalog:'
-        version: 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        version: 0.4.5(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@opentui/solid':
         specifier: 'catalog:'
-        version: 0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        version: 0.4.5(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@types/bun':
         specifier: ^1.3.14
         version: 1.3.14
@@ -301,13 +311,13 @@ importers:
     devDependencies:
       '@opentui/core':
         specifier: 'catalog:'
-        version: 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        version: 0.4.5(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@opentui/react':
         specifier: 'catalog:'
-        version: 0.4.3(react-devtools-core@7.0.1)(react@19.2.7)(typescript@5.9.3)(web-tree-sitter@0.25.10)(ws@8.21.0)
+        version: 0.4.5(react-devtools-core@7.0.1)(react@19.2.7)(typescript@5.9.3)(web-tree-sitter@0.25.10)(ws@8.21.0)
       '@opentui/solid':
         specifier: 'catalog:'
-        version: 0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        version: 0.4.5(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@tuiparts/utils':
         specifier: workspace:^
         version: link:../utils
@@ -340,7 +350,7 @@ importers:
     devDependencies:
       '@opentui/core':
         specifier: 'catalog:'
-        version: 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        version: 0.4.5(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@types/bun':
         specifier: ^1.3.14
         version: 1.3.14
@@ -358,13 +368,13 @@ importers:
     devDependencies:
       '@opentui/core':
         specifier: 'catalog:'
-        version: 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        version: 0.4.5(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@opentui/react':
         specifier: 'catalog:'
-        version: 0.4.3(react-devtools-core@7.0.1)(react@19.2.7)(typescript@5.9.3)(web-tree-sitter@0.25.10)(ws@8.21.0)
+        version: 0.4.5(react-devtools-core@7.0.1)(react@19.2.7)(typescript@5.9.3)(web-tree-sitter@0.25.10)(ws@8.21.0)
       '@opentui/solid':
         specifier: 'catalog:'
-        version: 0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        version: 0.4.5(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@tuiparts/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1566,62 +1576,121 @@ packages:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
-  '@opentui/core-darwin-arm64@0.4.3':
-    resolution: {integrity: sha512-p5+7AAxpxGuDGagyQfewKtmTFnN7THvTVY4FyKqUtJomNaHdQXPHztapNNzMx0DGWbwOUbVKzpL+yc3CZY3chQ==}
+  '@opentui/core-darwin-arm64@0.4.5':
+    resolution: {integrity: sha512-8KUG0oRidnR+oW1RSZJ72/PhZLl+qRRMk5U/mieF4c0SJ5V3tYACpBZAKzQfHNd1f7QzD8FHZct1lPpQgtmkWg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@opentui/core-darwin-x64@0.4.3':
-    resolution: {integrity: sha512-+fh0vEUE0lwVC7RW5ijYLRlTLp5NfvCRj8SzxDVd7IL2j2ssB6YXcfIbXq2EW7UGnrejwPRXf1tgUrIXW9KmOw==}
+  '@opentui/core-darwin-arm64@0.5.10':
+    resolution: {integrity: sha512-Vyb+nTbhab8ZcRy5gg1loEEGwRcIbjAeVRIBfHBcbFDqmITBOg7x2gqJ+x/TnoOy4uwMhCmICUN2wiyREw3r1Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@opentui/core-darwin-x64@0.4.5':
+    resolution: {integrity: sha512-R2bocsg55gwjOqCp/MWFgFYzRmsduKegB6nzgFAPCvAD/L5Jf30xpWJWFlSg3x8vxe1L9WJ84dfqa4M7mZZ3wA==}
     cpu: [x64]
     os: [darwin]
 
-  '@opentui/core-linux-arm64-musl@0.4.3':
-    resolution: {integrity: sha512-8p8g8/AEq/xFGpQ7XcIFKcAqjc0QwsZcv+Ll9RbCDpUA56FGH6jfLDir0KYTNTgYXJTIrBIENI9K46VuxMUMQA==}
+  '@opentui/core-darwin-x64@0.5.10':
+    resolution: {integrity: sha512-tTFLcM7Oj1gTyhm/bUdAt3C6grZdCxPk6+/g2azcZBUlI3/62LwbeRS6HbQKFFmm+1fUmX8cq6kWrtul885mVg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@opentui/core-linux-arm64-musl@0.4.5':
+    resolution: {integrity: sha512-ieqdyKI6EIYPalYAETB2wsdP83hr5Ifi+dFnBFUmdEEFHsoKwBmn2S7bsTOYlX7Bg03F4/YPIg+IvRpeC+cUJw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@opentui/core-linux-arm64@0.4.3':
-    resolution: {integrity: sha512-gl6qA5QJy6u8Cbt7gOtHbhhfMZ4qQDb0kEwFXHcMGmbnKzz4OHoq74D6tNjyvSQB9saoC7C6C0tvn2DcJOuNog==}
+  '@opentui/core-linux-arm64-musl@0.5.10':
+    resolution: {integrity: sha512-dGMphDKexSdeYqwl0wgoFBP88Ta/cdi1Zc1mk29/ENkSCGz+74zlCHgqTHRNGLmI8W5TfuUtCyktQH11/Z+TBQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@opentui/core-linux-arm64@0.4.5':
+    resolution: {integrity: sha512-R4MZ25a4CzOAGVjW9aj1hUfzQGVfCJwrwBDbNs2SXaIvzcZqkxCVtU4FoQ5LsaD0j/BdNQVg2CIfFkFsm1fDuQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@opentui/core-linux-x64-musl@0.4.3':
-    resolution: {integrity: sha512-/QiFpCrpU2O7vy8QYmLIQYbvAtKDgmqcVjR7dGtqSzkiQk3ktNJoo5RozG7ueXnjung1Wp0nKldKxo2Csg/OrA==}
+  '@opentui/core-linux-arm64@0.5.10':
+    resolution: {integrity: sha512-ncJXcgudhBf2GdJyF3xVQN/Ec+1F7GOL+pRrURmgBYSj2v1w6EyoDQFAACtPTK2c3R38W6fvZwL4JSLlm4EFXQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@opentui/core-linux-x64-musl@0.4.5':
+    resolution: {integrity: sha512-mKVKcIcPiSVVZZsdPSBoWwoa2/TCeQAaMDeHF7PFw2kt5bTXZPP7xxWfRQLCNIcA1eaGl59UuwUWHDR2Ve548Q==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@opentui/core-linux-x64@0.4.3':
-    resolution: {integrity: sha512-dXpJitiZdYE3hq2Pvx6e9I0uPQSOcnaLLp1pDgWAHv+3kvKSHEX//9Yr/pV/Ua6qqT7p+2D/K4vXNap/NKVo2w==}
+  '@opentui/core-linux-x64-musl@0.5.10':
+    resolution: {integrity: sha512-Oj4H9hApuvuTKPWxh4SoZAgGJorR7vbvnrZA/cAkSMAk2VGSoHRRcqeXQbcH8IcdjVZ0KFpv8Zkl/D5Ye+2mew==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@opentui/core-linux-x64@0.4.5':
+    resolution: {integrity: sha512-SNyuQoxMKI1vuJhgxSSW96adWM6LqFl2SoS3GM4tGeneGOanVVG2Y06PvlytXvF4cKik97t0rqkVMRetmOs93w==}
     cpu: [x64]
     os: [linux]
 
-  '@opentui/core-win32-arm64@0.4.3':
-    resolution: {integrity: sha512-Mx2zuOjrhm/z2SDS6RExIyjP/SnN/8QhhagxURUw0jQi/NssGSeAllu1cBAFFnhobJL5QLTE4FU4CRhUK9svgg==}
+  '@opentui/core-linux-x64@0.5.10':
+    resolution: {integrity: sha512-5qtYaOgwVycZD1GaGshTRsi0rXPAmVExO03N1JQaHu+NYxK/vXSOc7Bu4QW0sPXx3Sp0SpzpP+FHjXABfoK66g==}
+    cpu: [x64]
+    os: [linux]
+
+  '@opentui/core-win32-arm64@0.4.5':
+    resolution: {integrity: sha512-GHTTsqeR45q2Iek9Rb7ty+x/hAKn2jZ1ujlCgPR8LBKyF7h0E1dNFryoZ7ehMc3kJndP1sKn836IemKFqxuDdQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@opentui/core-win32-x64@0.4.3':
-    resolution: {integrity: sha512-NuoqvWKGXaYnmlqvu7Gg2lLI6yVMnS9OfWBvxp+7Q+McSgHFSTQmYBXaPpvQ8HikpQXE1nCeMPtuSG4PdZHe2w==}
+  '@opentui/core-win32-arm64@0.5.10':
+    resolution: {integrity: sha512-A9VhgvTxQoUdZ+8LmUumEng1sQNbj9QQQT3NYG9mSxI54qTANi7vOWNSphMiY6RMVsr22pgm6nUvSSvJXv7Jog==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@opentui/core-win32-x64@0.4.5':
+    resolution: {integrity: sha512-Y8T/yXCDGagRGiQrtmuB6AhRcPucKFs/Dre3v8kJwNYqDccI4FzUPKclZ7djfmRZNjl7JUqPhZZP/PwDpQocMg==}
     cpu: [x64]
     os: [win32]
 
-  '@opentui/core@0.4.3':
-    resolution: {integrity: sha512-rrJfAk13tALDqldYjhc78eWQ+aKq1iknJgffIOg3OwyZoqQo+p6gtuqyhmWvXIfQzlNUbpgpCPcxbXlhMnlaHQ==}
+  '@opentui/core-win32-x64@0.5.10':
+    resolution: {integrity: sha512-u3KHa7kEeWrmKVDRJYpxSGO+g5E9cMGlrmTsPN3GVPHUmQMiREUawLXUvsU8+IHaQnqG3Q5nuE1yf4fPBzS+Qw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@opentui/core@0.4.5':
+    resolution: {integrity: sha512-JsgRTPkA6e+Vxmumxai6SElOSlRQkbzNKHlCfemlArRiLhfC1IZ9RXJo2QH4xSu+uBOWAM90uss73/pPlkdEig==}
     peerDependencies:
       web-tree-sitter: 0.25.10
 
-  '@opentui/react@0.4.3':
-    resolution: {integrity: sha512-HtC/+lMURaZlifiJNVsn84YqKMywXQmkeSNbUTlbbeS6YM6reahaacnZEYZdnEUgklO6+r/J1tG8UBhqO26X7Q==}
+  '@opentui/core@0.5.10':
+    resolution: {integrity: sha512-C3a2UbmefeAjIxAgm4BqjuSxKT4oqutfvYFwVvUgMxmGRHkNbBc/s7sukV0JgwcxFcV3uMFrXxo+E+BQtvuOiw==}
+    peerDependencies:
+      web-tree-sitter: 0.25.10
+
+  '@opentui/react@0.4.5':
+    resolution: {integrity: sha512-n88Vx0cMmAu++/S14WscjvdcT46IDcxve02jMtcfHQ9j6cySRHfILfGEpOB7xxc8RpCwQceEyOjkKkfzPzm6Jg==}
     peerDependencies:
       react: '>=19.2.0'
       react-devtools-core: ^7.0.1
       ws: ^8.18.0
 
-  '@opentui/solid@0.4.3':
-    resolution: {integrity: sha512-RcV0+S8HMdXOASyr7HmJUBuTUIaFPzAxMDa44VftS5C2JUgrmAuWo0Njv1q3TWRB1owjHnyKhEfWGKq7A82wxw==}
+  '@opentui/react@0.5.10':
+    resolution: {integrity: sha512-76UFqe/ML121Skjche2+mGX56GKTlwG3ftrOi3b7WGLvjGucPqgEDJ0+CmaC/Yk85O8ui/ZTZJ2tay/8foR4FQ==}
+    peerDependencies:
+      react: '>=19.2.0'
+      react-devtools-core: ^7.0.1
+      ws: ^8.18.0
+
+  '@opentui/solid@0.4.5':
+    resolution: {integrity: sha512-B0RSkXnrtPVfEJOX+Hj+axjLJ3lzbG1BZw5I7Pvb9OPp48Vzg2cW2a3cSa86/q48ndLt647i/XwFPIw/jqnI5g==}
+    peerDependencies:
+      solid-js: 1.9.12
+
+  '@opentui/solid@0.5.10':
+    resolution: {integrity: sha512-KrmMIsHiKBHOABTC0brOwqWm+sGq1ZX2sGCAx6WgtBbE3STMup9n8TAy/6gUYhwcjC9zugT53ytfSVwCwVWZUg==}
     peerDependencies:
       solid-js: 1.9.12
 
@@ -2883,6 +2952,11 @@ packages:
 
   bun-ffi-structs@0.2.4:
     resolution: {integrity: sha512-AJzsqoVFs1KBbJbWHIYrVZLDC3NhTqqh25awRXqzoLzmBAKr5oqk6+CwuYHAekKx+VBCYVohBoKuRq40dV+TYg==}
+    peerDependencies:
+      typescript: ^5
+
+  bun-ffi-structs@0.3.1:
+    resolution: {integrity: sha512-3gM7PpVWLyrwxWjcilSiGuhWanhZivvo6l0u573NziPH6f/gwk6McbaYgn7oJWov6pKGRTDbrg94W5DcJsKTtQ==}
     peerDependencies:
       typescript: ^5
 
@@ -7520,31 +7594,55 @@ snapshots:
 
   '@opentelemetry/api@1.9.0': {}
 
-  '@opentui/core-darwin-arm64@0.4.3':
+  '@opentui/core-darwin-arm64@0.4.5':
     optional: true
 
-  '@opentui/core-darwin-x64@0.4.3':
+  '@opentui/core-darwin-arm64@0.5.10':
     optional: true
 
-  '@opentui/core-linux-arm64-musl@0.4.3':
+  '@opentui/core-darwin-x64@0.4.5':
     optional: true
 
-  '@opentui/core-linux-arm64@0.4.3':
+  '@opentui/core-darwin-x64@0.5.10':
     optional: true
 
-  '@opentui/core-linux-x64-musl@0.4.3':
+  '@opentui/core-linux-arm64-musl@0.4.5':
     optional: true
 
-  '@opentui/core-linux-x64@0.4.3':
+  '@opentui/core-linux-arm64-musl@0.5.10':
     optional: true
 
-  '@opentui/core-win32-arm64@0.4.3':
+  '@opentui/core-linux-arm64@0.4.5':
     optional: true
 
-  '@opentui/core-win32-x64@0.4.3':
+  '@opentui/core-linux-arm64@0.5.10':
     optional: true
 
-  '@opentui/core@0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)':
+  '@opentui/core-linux-x64-musl@0.4.5':
+    optional: true
+
+  '@opentui/core-linux-x64-musl@0.5.10':
+    optional: true
+
+  '@opentui/core-linux-x64@0.4.5':
+    optional: true
+
+  '@opentui/core-linux-x64@0.5.10':
+    optional: true
+
+  '@opentui/core-win32-arm64@0.4.5':
+    optional: true
+
+  '@opentui/core-win32-arm64@0.5.10':
+    optional: true
+
+  '@opentui/core-win32-x64@0.4.5':
+    optional: true
+
+  '@opentui/core-win32-x64@0.5.10':
+    optional: true
+
+  '@opentui/core@0.4.5(typescript@5.9.3)(web-tree-sitter@0.25.10)':
     dependencies:
       bun-ffi-structs: 0.2.4(typescript@5.9.3)
       diff: 9.0.0
@@ -7553,20 +7651,40 @@ snapshots:
       strip-ansi: 7.1.2
       web-tree-sitter: 0.25.10
     optionalDependencies:
-      '@opentui/core-darwin-arm64': 0.4.3
-      '@opentui/core-darwin-x64': 0.4.3
-      '@opentui/core-linux-arm64': 0.4.3
-      '@opentui/core-linux-arm64-musl': 0.4.3
-      '@opentui/core-linux-x64': 0.4.3
-      '@opentui/core-linux-x64-musl': 0.4.3
-      '@opentui/core-win32-arm64': 0.4.3
-      '@opentui/core-win32-x64': 0.4.3
+      '@opentui/core-darwin-arm64': 0.4.5
+      '@opentui/core-darwin-x64': 0.4.5
+      '@opentui/core-linux-arm64': 0.4.5
+      '@opentui/core-linux-arm64-musl': 0.4.5
+      '@opentui/core-linux-x64': 0.4.5
+      '@opentui/core-linux-x64-musl': 0.4.5
+      '@opentui/core-win32-arm64': 0.4.5
+      '@opentui/core-win32-x64': 0.4.5
     transitivePeerDependencies:
       - typescript
 
-  '@opentui/react@0.4.3(react-devtools-core@7.0.1)(react@19.2.7)(typescript@5.9.3)(web-tree-sitter@0.25.10)(ws@8.21.0)':
+  '@opentui/core@0.5.10(typescript@5.9.3)(web-tree-sitter@0.25.10)':
     dependencies:
-      '@opentui/core': 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
+      bun-ffi-structs: 0.3.1(typescript@5.9.3)
+      diff: 9.0.0
+      marked: 17.0.1
+      string-width: 7.2.0
+      strip-ansi: 7.1.2
+      web-tree-sitter: 0.25.10
+    optionalDependencies:
+      '@opentui/core-darwin-arm64': 0.5.10
+      '@opentui/core-darwin-x64': 0.5.10
+      '@opentui/core-linux-arm64': 0.5.10
+      '@opentui/core-linux-arm64-musl': 0.5.10
+      '@opentui/core-linux-x64': 0.5.10
+      '@opentui/core-linux-x64-musl': 0.5.10
+      '@opentui/core-win32-arm64': 0.5.10
+      '@opentui/core-win32-x64': 0.5.10
+    transitivePeerDependencies:
+      - typescript
+
+  '@opentui/react@0.4.5(react-devtools-core@7.0.1)(react@19.2.7)(typescript@5.9.3)(web-tree-sitter@0.25.10)(ws@8.21.0)':
+    dependencies:
+      '@opentui/core': 0.4.5(typescript@5.9.3)(web-tree-sitter@0.25.10)
       react: 19.2.7
       react-devtools-core: 7.0.1
       react-reconciler: 0.33.0(react@19.2.7)
@@ -7575,11 +7693,37 @@ snapshots:
       - typescript
       - web-tree-sitter
 
-  '@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)':
+  '@opentui/react@0.5.10(react-devtools-core@7.0.1)(react@19.2.7)(typescript@5.9.3)(web-tree-sitter@0.25.10)(ws@8.21.0)':
+    dependencies:
+      '@opentui/core': 0.5.10(typescript@5.9.3)(web-tree-sitter@0.25.10)
+      react: 19.2.7
+      react-devtools-core: 7.0.1
+      react-reconciler: 0.33.0(react@19.2.7)
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - typescript
+      - web-tree-sitter
+
+  '@opentui/solid@0.4.5(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.0)
-      '@opentui/core': 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
+      '@opentui/core': 0.4.5(typescript@5.9.3)(web-tree-sitter@0.25.10)
+      babel-plugin-module-resolver: 5.0.2
+      babel-preset-solid: 1.9.12(@babel/core@7.28.0)(solid-js@1.9.12)
+      entities: 7.0.1
+      s-js: 0.4.9
+      solid-js: 1.9.12
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+      - web-tree-sitter
+
+  '@opentui/solid@0.5.10(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/preset-typescript': 7.27.1(@babel/core@7.28.0)
+      '@opentui/core': 0.5.10(typescript@5.9.3)(web-tree-sitter@0.25.10)
       babel-plugin-module-resolver: 5.0.2
       babel-preset-solid: 1.9.12(@babel/core@7.28.0)(solid-js@1.9.12)
       entities: 7.0.1
@@ -8827,6 +8971,10 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.6)
 
   bun-ffi-structs@0.2.4(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
+  bun-ffi-structs@0.3.1(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,16 @@ catalog:
   "@types/node": "^24.13.3"
   "ws": "^8.21.0"
 
+catalogs:
+  dialog-dev:
+    "@opentui/core": "^0.5.10"
+    "@opentui/react": "^0.5.10"
+    "@opentui/solid": "^0.5.10"
+  dialog-peer:
+    "@opentui/core": ">=0.4.3 <0.6.0"
+    "@opentui/react": ">=0.4.3 <0.6.0"
+    "@opentui/solid": ">=0.4.3 <0.6.0"
+
 overrides:
   "@babel/core@<=7.29.0": "7.29.7"
 


### PR DESCRIPTION
## Summary

- restore the independently published @opentui-ui/dialog package identity
- support OpenTUI 0.4.3 through 0.5.x
- fix Dialog removal and React/Solid provider teardown
- add Core, React, and Solid regression coverage
- add packed-consumer validation for all Dialog entry points

## Validation

- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm validate:packages
- pnpm --filter www build

This PR intentionally excludes Toast changes; Toast remains for a separate audit and release.