### PR TITLE
feat(docs): add GitHub star conversion path

### DIFF
--- a/apps/www/components.ts
+++ b/apps/www/components.ts
@@ -1,0 +1,12 @@
+import { defineComponents } from "blume";
+import GitHubStar from "./components/GitHubStar.astro";
+import HeaderSearch from "./components/HeaderSearch.astro";
+
+export default defineComponents({
+  layout: {
+    Search: HeaderSearch,
+  },
+  mdx: {
+    GitHubStar,
+  },
+});

--- a/apps/www/components/GitHubStar.astro
+++ b/apps/www/components/GitHubStar.astro
@@ -1,0 +1,207 @@
+---
+interface Props {
+  placement: "catalog" | "header" | "quickstart";
+}
+
+const { placement } = Astro.props;
+const isHeader = placement === "header";
+const eventName = {
+  catalog: "github_catalog_click",
+  header: "github_header_click",
+  quickstart: "github_quickstart_cta_click",
+}[placement];
+const repositoryUrl = "https://github.com/tuiparts/tuiparts";
+---
+
+{
+  isHeader ? (
+    <a
+      class="github-star github-star--header"
+      data-analytics-event={eventName}
+      href={repositoryUrl}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="18"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="1.8"
+        viewBox="0 0 24 24"
+        width="18"
+      >
+        <path d="m12 2.8 2.75 5.58 6.16.9-4.46 4.34 1.05 6.13L12 16.86l-5.5 2.89 1.05-6.13-4.46-4.34 6.16-.9L12 2.8Z" />
+      </svg>
+      <span class="github-star__header-label">Star</span>
+      <span class="sr-only">tuiparts on GitHub (opens in a new tab)</span>
+    </a>
+  ) : (
+    <aside class="github-star github-star--panel" aria-labelledby={`github-star-${placement}`}>
+      <div>
+        <p class="github-star__eyebrow">Follow the project</p>
+        <h2 class="github-star__title" id={`github-star-${placement}`}>
+          Building with tuiparts?
+        </h2>
+        <p class="github-star__copy">
+          Star the repository to follow new Primitives, Recipes, and release updates.
+        </p>
+      </div>
+      <a
+        class="github-star__action"
+        data-analytics-event={eventName}
+        href={repositoryUrl}
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <svg
+          aria-hidden="true"
+          fill="none"
+          height="18"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.8"
+          viewBox="0 0 24 24"
+          width="18"
+        >
+          <path d="m12 2.8 2.75 5.58 6.16.9-4.46 4.34 1.05 6.13L12 16.86l-5.5 2.89 1.05-6.13-4.46-4.34 6.16-.9L12 2.8Z" />
+        </svg>
+        Star on GitHub
+        <span class="sr-only">(opens in a new tab)</span>
+      </a>
+    </aside>
+  )
+}
+
+<style>
+  .github-star {
+    font-family: var(--blume-font-body);
+  }
+
+  .github-star--header {
+    display: inline-flex;
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+    align-items: center;
+    justify-content: center;
+    gap: 0.45rem;
+    border: 1px solid var(--blume-border);
+    border-radius: 999px;
+    color: var(--blume-foreground);
+    font-size: 0.8125rem;
+    font-weight: 600;
+    line-height: 1;
+    text-decoration: none;
+    transition:
+      border-color 150ms ease,
+      background-color 150ms ease,
+      transform 150ms cubic-bezier(0.23, 1, 0.32, 1);
+  }
+
+  .github-star--header:hover {
+    border-color: var(--blume-accent);
+    background: var(--blume-muted);
+  }
+
+  .github-star--header:active,
+  .github-star__action:active {
+    transform: scale(0.96);
+  }
+
+  .github-star__header-label {
+    display: none;
+  }
+
+  .github-star--panel {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1.5rem;
+    margin-block: 3rem 0;
+    padding-block: 1.5rem;
+    border-block: 1px solid var(--blume-border);
+  }
+
+  .github-star__eyebrow {
+    margin: 0;
+    color: var(--blume-accent);
+    font-family: var(--blume-font-mono);
+    font-size: 0.75rem;
+    letter-spacing: 0.12em;
+    line-height: 1.5;
+    text-transform: uppercase;
+  }
+
+  .github-star__title {
+    margin: 0.4rem 0 0;
+    color: var(--blume-foreground);
+    font-family: var(--blume-font-display);
+    font-size: 1.125rem;
+    font-weight: 700;
+    line-height: 1.4;
+  }
+
+  .github-star__copy {
+    max-width: 34rem;
+    margin: 0.35rem 0 0;
+    color: var(--blume-muted-foreground);
+    font-size: 0.875rem;
+    line-height: 1.6;
+  }
+
+  .github-star__action {
+    display: inline-flex;
+    min-height: 2.75rem;
+    flex: none;
+    align-items: center;
+    justify-content: center;
+    gap: 0.55rem;
+    padding-inline: 1rem;
+    border-radius: var(--blume-radius);
+    background: var(--blume-accent);
+    color: var(--blume-accent-foreground);
+    font-size: 0.875rem;
+    font-weight: 600;
+    line-height: 1;
+    text-decoration: none;
+    transition:
+      background-color 150ms ease,
+      transform 150ms cubic-bezier(0.23, 1, 0.32, 1);
+  }
+
+  .github-star__action:hover {
+    background: var(--tp-action-hover);
+  }
+
+  :where(.github-star--header, .github-star__action):focus-visible {
+    outline: 2px solid var(--blume-accent);
+    outline-offset: 3px;
+  }
+
+  @media (min-width: 64rem) {
+    .github-star--header {
+      min-width: auto;
+      padding-inline: 0.8rem;
+    }
+
+    .github-star__header-label {
+      display: inline;
+    }
+
+    .github-star--panel {
+      flex-direction: row;
+      align-items: center;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .github-star--header,
+    .github-star__action {
+      transition-duration: 0.01ms;
+    }
+  }
+</style>

--- a/apps/www/components/HeaderSearch.astro
+++ b/apps/www/components/HeaderSearch.astro
@@ -1,0 +1,9 @@
+---
+import Search from "blume/components/layout/Search.astro";
+import GitHubStar from "./GitHubStar.astro";
+
+const searchProps = Astro.props;
+---
+
+<Search {...searchProps} />
+<GitHubStar placement="header" />

--- a/apps/www/components/LandingHeaderStar.astro
+++ b/apps/www/components/LandingHeaderStar.astro
@@ -1,0 +1,33 @@
+---
+import GitHubStar from "./GitHubStar.astro";
+---
+
+<tuiparts-header-star>
+  <GitHubStar placement="header" />
+</tuiparts-header-star>
+
+<script>
+  class TuipartsHeaderStar extends HTMLElement {
+    connectedCallback() {
+      const header = document.querySelector("[data-blume-header]");
+      const star = this.querySelector(".github-star--header");
+      const actionCluster = header?.lastElementChild;
+
+      if (header && star && actionCluster) {
+        header.insertBefore(star, actionCluster);
+      }
+
+      this.remove();
+    }
+  }
+
+  if (!customElements.get("tuiparts-header-star")) {
+    customElements.define("tuiparts-header-star", TuipartsHeaderStar);
+  }
+</script>
+
+<style>
+  tuiparts-header-star {
+    display: none;
+  }
+</style>

--- a/apps/www/docs/catalog/index.mdx
+++ b/apps/www/docs/catalog/index.mdx
@@ -50,3 +50,5 @@ When a Recipe's composition or public API does not fit, use the underlying
 [Primitive](/primitives) to assemble the behavior yourself. To understand the
 ownership boundary, read [Architecture](/architecture). To compare upstream
 source after installation, read [Registry](/registry#review-updates).
+
+<GitHubStar placement="catalog" />

--- a/apps/www/docs/quickstart.mdx
+++ b/apps/www/docs/quickstart.mdx
@@ -69,3 +69,5 @@ glyphs, borders, and density, edit `components/ui/theme.ts` instead.
     Compare upstream Recipe changes with your local source.
   </Card>
 </CardGroup>
+
+<GitHubStar placement="quickstart" />

--- a/apps/www/pages/index.astro
+++ b/apps/www/pages/index.astro
@@ -3,6 +3,7 @@ import data from "blume:data";
 import CodeBlock from "blume/components/content/CodeBlock.astro";
 import CodeGroup from "blume/components/content/CodeGroup.astro";
 import PageLayout from "blume/components/layout/PageLayout.astro";
+import LandingHeaderStar from "../components/LandingHeaderStar.astro";
 
 const { config } = data;
 
@@ -124,6 +125,7 @@ const pillars = [
     description: config.description,
   }}
 >
+  <LandingHeaderStar />
   <script is:inline>document.documentElement.classList.add("js");</script>
 
   {/* ── Hero — title left, live terminal render right ── */}

--- a/apps/www/theme.css
+++ b/apps/www/theme.css
@@ -152,6 +152,13 @@ body {
   }
 }
 
+/* The Search slot adds the explicit star action. Hide Blume's duplicate
+   icon-only repository link while preserving its source/edit-page links. */
+[data-blume-header]:has(.github-star--header)
+  a[aria-label][href="https://github.com/tuiparts/tuiparts"] {
+  display: none;
+}
+
 ::selection {
   background: var(--tp-selection);
 }


### PR DESCRIPTION
## Summary

- add a persistent, responsive Star on GitHub action to the docs header and custom landing-page header
- add contextual repository prompts after Quick start and the Catalog overview
- expose stable outbound-event identifiers for future privacy-respecting analytics
- preserve an icon-only GitHub fallback when JavaScript is unavailable on the custom landing page

## Validation

- isolated Blume production build: 40 pages built successfully
- targeted Biome checks passed
- git diff --check passed
- browser-verified at desktop and 390px mobile widths with no horizontal overflow

## Existing warnings

The build continues to report the pre-existing Catalog and Primitives index-title mismatch warnings. This PR does not introduce or alter them.